### PR TITLE
CTAA-1383: Request temporary exposure keys on report submission

### DIFF
--- a/CoronaContact/Logic/ReportHealthStatusFlowController.swift
+++ b/CoronaContact/Logic/ReportHealthStatusFlowController.swift
@@ -11,34 +11,33 @@ class ReportHealthStatusFlowController {
     @Injected private var exposureManager: ExposureManager
     @Injected private var networkService: NetworkService
 
-    enum Flow {
-        case personalData
-        case tanConfirmation
-        case statusReport
-        case done
+    typealias Completion<Success> = (Result<Success, ReportError>) -> Void
+
+    enum ReportError: Error {
+        case unknown
+        case tanConfirmation(NetworkService.DisplayableError)
+        case submission(NetworkService.TracingKeysError)
     }
 
     private let diagnosisType: DiagnosisType
-    private var flow: Flow = .personalData
     private var tanUUID: String?
-    private var tracingKeys: TracingKeys?
+    private var verification: Verification?
     var personalData: PersonalData?
 
     init(diagnosisType: DiagnosisType) {
         self.diagnosisType = diagnosisType
     }
 
-    func tanConfirmation(personalData: PersonalData, completion: @escaping (Result<Void, NetworkService.DisplayableError>) -> Void) {
+    func tanConfirmation(personalData: PersonalData, completion: @escaping Completion<Void>) {
         self.personalData = personalData
 
         networkService.requestTan(mobileNumber: personalData.mobileNumber) { [weak self] result in
             switch result {
             case let .success(response):
                 self?.tanUUID = response.uuid
-                self?.flow = .tanConfirmation
                 completion(.success(()))
             case let .failure(error):
-                completion(.failure(error))
+                completion(.failure(.tanConfirmation(error)))
             }
         }
     }
@@ -48,43 +47,64 @@ class ReportHealthStatusFlowController {
             return
         }
 
-        let verfication = Verification(uuid: tanUUID, authorization: tanNumber)
+        verification = Verification(uuid: tanUUID, authorization: tanNumber)
+    }
+
+    func submit(completion: @escaping Completion<Void>) {
+        getDiagnoisKeys { [weak self] result in
+            switch result {
+            case let .success(tracingKeys):
+                self?.sendTracingKeys(tracingKeys, completion: completion)
+            case let .failure(error):
+                completion(.failure(error))
+            }
+        }
+    }
+
+    private func getDiagnoisKeys(completion: @escaping Completion<TracingKeys>) {
+        guard let verification = verification else {
+            failSilently(completion)
+            return
+        }
 
         exposureManager.getDiagnosisKeys { [weak self] result in
+            guard let self = self else {
+                return
+            }
+
             switch result {
             case let .success(temporaryExposureKeys):
-                self?.flow = .statusReport
-                self?.parseTemporaryExposureKeys(temporaryExposureKeys, verification: verfication)
+                let tracingKeys = self.parseTemporaryExposureKeys(temporaryExposureKeys, verification: verification)
+                completion(.success(tracingKeys))
             case let .failure(error):
                 LoggingService.error("Couldn't get diagnosis keys from the exposure manager: \(error)", context: .exposure)
+                self.failSilently(completion)
             }
         }
     }
 
     private func parseTemporaryExposureKeys(_ temporaryExposureKeys: [ENTemporaryExposureKey],
-                                            verification: Verification) {
+                                            verification: Verification) -> TracingKeys {
         let temporaryExposureKeys = temporaryExposureKeys.map(TemporaryExposureKey.init)
-        tracingKeys = TracingKeys(
+        return TracingKeys(
             temporaryExposureKeys: temporaryExposureKeys,
             diagnosisType: diagnosisType,
             verificationPayload: verification
         )
     }
 
-    func submit(completion: @escaping (Result<Void, NetworkService.TracingKeysError>) -> Void) {
-        guard let tracingKeys = tracingKeys else {
-            return
-        }
-
-        networkService.sendTracingKeys(tracingKeys) { [weak self] result in
+    private func sendTracingKeys(_ tracingKeys: TracingKeys, completion: @escaping Completion<Void>) {
+        networkService.sendTracingKeys(tracingKeys) { result in
             switch result {
-            case let .success(response):
-                print(response)
-                self?.flow = .done
+            case .success:
                 completion(.success(()))
             case let .failure(error):
-                completion(.failure(error))
+                completion(.failure(.submission(error)))
             }
         }
+    }
+
+    private func failSilently<Success>(_ completion: @escaping Completion<Success>) {
+        completion(.failure(.unknown))
     }
 }

--- a/CoronaContact/Scenes/Revocation/PersonalData/RevocationPersonalDataViewModel.swift
+++ b/CoronaContact/Scenes/Revocation/PersonalData/RevocationPersonalDataViewModel.swift
@@ -28,10 +28,12 @@ class RevocationPersonalDataViewModel: ViewModel {
             completion()
 
             switch result {
-            case let .failure(error):
+            case let .failure(.tanConfirmation(error)):
                 self?.coordinator?.showErrorAlert(title: error.title, error: error.description)
             case .success:
                 self?.coordinator?.tanConfirmation()
+            default:
+                break
             }
         }
     }

--- a/CoronaContact/Scenes/Revocation/StatusReport/RevocationStatusReportViewModel.swift
+++ b/CoronaContact/Scenes/Revocation/StatusReport/RevocationStatusReportViewModel.swift
@@ -46,7 +46,7 @@ class RevocationStatusReportViewModel: ViewModel {
             completion()
 
             switch result {
-            case let .failure(error):
+            case let .failure(.submission(error)):
                 self?.coordinator?.showErrorAlert(
                     title: error.displayableError.title,
                     error: error.displayableError.description,
@@ -60,6 +60,8 @@ class RevocationStatusReportViewModel: ViewModel {
                 )
             case .success:
                 self?.coordinator?.showConfirmation()
+            default:
+                break
             }
         }
     }

--- a/CoronaContact/Scenes/Revocation/TanConfirmation/RevocationTanConfirmationViewModel.swift
+++ b/CoronaContact/Scenes/Revocation/TanConfirmation/RevocationTanConfirmationViewModel.swift
@@ -30,9 +30,11 @@ class RevocationTanConfirmationViewModel: ViewModel {
             completion()
 
             switch result {
-            case let .failure(error):
+            case let .failure(.tanConfirmation(error)):
                 self?.coordinator?.showErrorAlert(title: error.title, error: error.description)
             case .success:
+                break
+            default:
                 break
             }
         }

--- a/CoronaContact/Scenes/RevokeSickness/PersonalData/RevokeSicknessPersonalDataViewModel.swift
+++ b/CoronaContact/Scenes/RevokeSickness/PersonalData/RevokeSicknessPersonalDataViewModel.swift
@@ -28,10 +28,12 @@ class RevokeSicknessPersonalDataViewModel: ViewModel {
             completion()
 
             switch result {
-            case let .failure(error):
+            case let .failure(.tanConfirmation(error)):
                 self?.coordinator?.showErrorAlert(title: error.title, error: error.description)
             case .success:
                 self?.coordinator?.tanConfirmation()
+            default:
+                break
             }
         }
     }

--- a/CoronaContact/Scenes/RevokeSickness/StatusReport/RevokeSicknessStatusReportViewModel.swift
+++ b/CoronaContact/Scenes/RevokeSickness/StatusReport/RevokeSicknessStatusReportViewModel.swift
@@ -46,7 +46,7 @@ class RevokeSicknessStatusReportViewModel: ViewModel {
             completion()
 
             switch result {
-            case let .failure(error):
+            case let .failure(.submission(error)):
                 self?.coordinator?.showErrorAlert(
                     title: error.displayableError.title,
                     error: error.displayableError.description,
@@ -60,6 +60,8 @@ class RevokeSicknessStatusReportViewModel: ViewModel {
                 )
             case .success:
                 self?.coordinator?.showConfirmation()
+            default:
+                break
             }
         }
     }

--- a/CoronaContact/Scenes/RevokeSickness/TanConfirmation/RevokeSicknessTanConfirmationViewModel.swift
+++ b/CoronaContact/Scenes/RevokeSickness/TanConfirmation/RevokeSicknessTanConfirmationViewModel.swift
@@ -30,9 +30,11 @@ class RevokeSicknessTanConfirmationViewModel: ViewModel {
             completion()
 
             switch result {
-            case let .failure(error):
+            case let .failure(.tanConfirmation(error)):
                 self?.coordinator?.showErrorAlert(title: error.title, error: error.description)
             case .success:
+                break
+            default:
                 break
             }
         }

--- a/CoronaContact/Scenes/SelfTesting/Report/PersonalData/SelfTestingPersonalDataViewModel.swift
+++ b/CoronaContact/Scenes/SelfTesting/Report/PersonalData/SelfTestingPersonalDataViewModel.swift
@@ -28,10 +28,12 @@ class SelfTestingPersonalDataViewModel: ViewModel {
             completion()
 
             switch result {
-            case let .failure(error):
+            case let .failure(.tanConfirmation(error)):
                 self?.coordinator?.showErrorAlert(title: error.title, error: error.description)
             case .success:
                 self?.coordinator?.tanConfirmation()
+            default:
+                break
             }
         }
     }

--- a/CoronaContact/Scenes/SelfTesting/Report/StatusReport/SelfTestingStatusReportViewModel.swift
+++ b/CoronaContact/Scenes/SelfTesting/Report/StatusReport/SelfTestingStatusReportViewModel.swift
@@ -30,7 +30,7 @@ class SelfTestingStatusReportViewModel: ViewModel {
             completion()
 
             switch result {
-            case let .failure(error):
+            case let .failure(.submission(error)):
                 self?.coordinator?.showErrorAlert(
                     title: error.displayableError.title,
                     error: error.displayableError.description,
@@ -44,6 +44,8 @@ class SelfTestingStatusReportViewModel: ViewModel {
                 )
             case .success:
                 self?.coordinator?.showConfirmation()
+            default:
+                break
             }
         }
     }

--- a/CoronaContact/Scenes/SelfTesting/Report/TanConfirmation/SelfTestingTanConfirmationViewModel.swift
+++ b/CoronaContact/Scenes/SelfTesting/Report/TanConfirmation/SelfTestingTanConfirmationViewModel.swift
@@ -30,9 +30,11 @@ class SelfTestingTanConfirmationViewModel: ViewModel {
             completion()
 
             switch result {
-            case let .failure(error):
+            case let .failure(.tanConfirmation(error)):
                 self?.coordinator?.showErrorAlert(title: error.title, error: error.description)
             case .success:
+                break
+            default:
                 break
             }
         }

--- a/CoronaContact/Scenes/SicknessCertificate/PersonalData/SicknessCertificatePersonalDataViewModel.swift
+++ b/CoronaContact/Scenes/SicknessCertificate/PersonalData/SicknessCertificatePersonalDataViewModel.swift
@@ -28,10 +28,12 @@ class SicknessCertificatePersonalDataViewModel: ViewModel {
             completion()
 
             switch result {
-            case let .failure(error):
+            case let .failure(.tanConfirmation(error)):
                 self?.coordinator?.showErrorAlert(title: error.title, error: error.description)
             case .success:
                 self?.coordinator?.tanConfirmation()
+            default:
+                break
             }
         }
     }

--- a/CoronaContact/Scenes/SicknessCertificate/StatusReport/SicknessCertificateStatusReportViewModel.swift
+++ b/CoronaContact/Scenes/SicknessCertificate/StatusReport/SicknessCertificateStatusReportViewModel.swift
@@ -30,7 +30,7 @@ class SicknessCertificateStatusReportViewModel: ViewModel {
             completion()
 
             switch result {
-            case let .failure(error):
+            case let .failure(.submission(error)):
                 self?.coordinator?.showErrorAlert(
                     title: error.displayableError.title,
                     error: error.displayableError.description,
@@ -44,6 +44,8 @@ class SicknessCertificateStatusReportViewModel: ViewModel {
                 )
             case .success:
                 self?.coordinator?.showConfirmation()
+            default:
+                break
             }
         }
     }

--- a/CoronaContact/Scenes/SicknessCertificate/TanConfirmation/SicknessCertificateTanConfirmationViewModel.swift
+++ b/CoronaContact/Scenes/SicknessCertificate/TanConfirmation/SicknessCertificateTanConfirmationViewModel.swift
@@ -30,9 +30,11 @@ class SicknessCertificateTanConfirmationViewModel: ViewModel {
             completion()
 
             switch result {
-            case let .failure(error):
+            case let .failure(.tanConfirmation(error)):
                 self?.coordinator?.showErrorAlert(title: error.title, error: error.description)
             case .success:
+                break
+            default:
                 break
             }
         }


### PR DESCRIPTION
## Changes

* The system UI, which prompts the user to authorize the request of the temporary exposure keys, is now presented when the user submits a report (Revocation of suspected sickness, revocation of attested sickness, report of suspected sickness, report of attested sickness)